### PR TITLE
fix: wrong name of event variable in clickHandler

### DIFF
--- a/modules/BaseLink.js
+++ b/modules/BaseLink.js
@@ -23,7 +23,7 @@ class BaseLink extends Component {
             }
         }
 
-        let comboKey = event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+        let comboKey = evt.metaKey || evt.altKey || evt.ctrlKey || evt.shiftKey;
 
         if (evt.button === 0 && !comboKey) {
             evt.preventDefault();


### PR DESCRIPTION
Hi, I believe it's typo, at least our app reports `ReferenceError: event is not defined` in Firefox :).
